### PR TITLE
kaminariによるページング機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,18 @@ GEM
     jbuilder (2.6.4)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2)
+    kaminari (1.0.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.0.1)
+      kaminari-activerecord (= 1.0.1)
+      kaminari-core (= 1.0.1)
+    kaminari-actionview (1.0.1)
+      actionview
+      kaminari-core (= 1.0.1)
+    kaminari-activerecord (1.0.1)
+      activerecord
+      kaminari-core (= 1.0.1)
+    kaminari-core (1.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -176,6 +188,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.7)
   rails (~> 5.1.1)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.page(params[:page])
   end
 
   def show

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ActiveRecord::Base
   enum status: {todo: 0, doing: 1, done: 2}
   validates :content, presence: true
+  paginates_per 5
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,6 +4,7 @@
 <!-- 該当件数を表示 -->
 <%= page_entries_info @tasks %>
 <!-- /該当件数を表示 -->
+<%= link_to 'タスクを追加する', new_task_path %>
 <table>
   <thead>
     <tr>
@@ -28,4 +29,4 @@
 
 <br>
 <%= paginate @tasks %>
-<%= link_to 'New Task', new_task_path %>
+

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,9 +1,9 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Listing Tasks</h1>
-<!--  -->
+<!-- 該当件数を表示 -->
 <%= page_entries_info @tasks %>
-<!--  -->
+<!-- /該当件数を表示 -->
 <table>
   <thead>
     <tr>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,7 +1,9 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Listing Tasks</h1>
-
+<!--  -->
+<%= page_entries_info @tasks %>
+<!--  -->
 <table>
   <thead>
     <tr>
@@ -25,5 +27,5 @@
 </table>
 
 <br>
-
+<%= paginate @tasks %>
 <%= link_to 'New Task', new_task_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module Todo
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
-
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  helpers:
+    page_entries_info:
+      more_pages:
+        display_entries: "<b>%{total}</b>件中の<b>%{first} - %{last}件の</b>%{entry_name}を表示しています"
+      one_page:
+        display_entries:
+          one: "<b>%{count}</b>レコード表示中です %{entry_name}"
+          other: "<b>%{count}</b>レコード表示中です %{entry_name}"
+          zero: "レコードが見つかりませんでした %{entry_name}"
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      next: "次 &rsaquo;"
+      previous: "&lsaquo; 前"
+      truncate: "&hellip;"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,8 +8,7 @@
 50.times do |index|
   status_num = rand(0..2)
   Task.create(
-    id: index+1,
-    content:    "test-content#{index}",
+    content: "test-content#{index}",
     status: status_num,
   )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,11 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+50.times do |index|
+  status_num = rand(0..2)
+  Task.create(
+    id: index+1,
+    content:    "test-content#{index}",
+    status: status_num,
+  )
+end


### PR DESCRIPTION
##　概要
gemのkaminariを用いてページング機能を実装しました。
5件ごとにページングをするよう/app/models/task.rbに設定しています。

Modelの記述箇所はkaminariの[README.md](https://github.com/kaminari/kaminari#user-content-controllers)を参考にしました。

- [x] default_localeをjaに変更
- [x] 日本語表記のファイル(ja.yml)を追加
- [x] pagenationに必要な日本語表記を追加
- [x] 現在表示されているページとTaskの合計数を表示する項目を追加
- [ ] kaminari-bootstrapを入れる

## 確認いただきたいところ
そんなにファイルを編集せずにすんなりページングがうまく言ったので驚いたのですが、
設定漏れやこうした方がスマートなどないかご確認いただければと思います。

seedデータをもとにデータを投入
```
rake db:seed
rails s
```
 ## スクリーンショット
<img width="380" alt="2017-06-07 12 34 11" src="https://user-images.githubusercontent.com/13265134/26861346-2f54e8cc-4b7e-11e7-9d67-f7a31d64574c.png">

## レビュアー
@udzura @bake0937 @sunecosuri 